### PR TITLE
Consolidate weekday shift remediation

### DIFF
--- a/.github/workflows/scheduler-verification.yml
+++ b/.github/workflows/scheduler-verification.yml
@@ -14,6 +14,24 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            - name: Validate required secrets
+              env:
+                  EC2_HOST: ${{ secrets.EC2_HOST }}
+                  EC2_USER: ${{ secrets.EC2_USER }}
+                  EC2_SSH_KEY: ${{ secrets.EC2_SSH_KEY }}
+              run: |
+                  set -euo pipefail
+
+                  missing=()
+                  [ -z "${EC2_HOST:-}" ] && missing+=("EC2_HOST")
+                  [ -z "${EC2_USER:-}" ] && missing+=("EC2_USER")
+                  [ -z "${EC2_SSH_KEY:-}" ] && missing+=("EC2_SSH_KEY")
+
+                  if [ "${#missing[@]}" -gt 0 ]; then
+                    echo "::error::Missing required secrets: ${missing[*]}"
+                    exit 1
+                  fi
+
             - name: Checkout
               uses: actions/checkout@v4
 
@@ -43,7 +61,7 @@ jobs:
                     source .env
                     set +a
 
-                    OPEN_COUNT=$(MYSQL_PWD="$MYSQL_PASSWORD" mysql -h"${MYSQL_HOST:-localhost}" -u"${MYSQL_USER:-root}" -D man_hours -N -e "SELECT COUNT(*) FROM shifts WHERE updated_at IS NULL AND DATE(created_at)=CURDATE();")
+                    OPEN_COUNT=$(MYSQL_PWD="$MYSQL_PASSWORD" mysql -h"${MYSQL_HOST:-localhost}" -u"${MYSQL_USER:-root}" -D man_hours -N -e "SELECT COUNT(*) FROM shifts WHERE updated_at IS NULL AND (DATE(created_at) < CURDATE() OR (DATE(created_at)=CURDATE() AND TIME(created_at) < '18:00:00'));")
 
                     LOCK_OK="NO"
                     if [ -f /tmp/island_time_scheduler.lock ] && lsof /tmp/island_time_scheduler.lock 2>/dev/null | grep -q gunicorn; then
@@ -53,7 +71,7 @@ jobs:
                     HEALTH=$(curl -s -o /dev/null -w "%{http_code}" --unix-socket /home/ubuntu/TimeTrackerApp/Island_Time.sock http://localhost/ || echo "000")
 
                     TODAY=$(TZ=America/New_York date +%Y-%m-%d)
-                    if grep -q "$TODAY" gunicorn_error.log && grep -q "Weekday 6:00 PM auto clock-out completed" gunicorn_error.log; then
+                    if grep -h "$TODAY" gunicorn_error.log server.log 2>/dev/null | grep -q "SHIFT_REMEDIATION_COMPLETE"; then
                       FIRED="YES"
                     else
                       FIRED="NO"
@@ -73,10 +91,13 @@ jobs:
                     elif [ "$HEALTH" != "200" ]; then
                       VERDICT="FAIL"
                       REASON="App health check not 200"
+                    elif [ "$FIRED" != "YES" ]; then
+                      VERDICT="FAIL"
+                      REASON="Shift remediation summary log missing for today"
                     elif [ "$DOW_ET" -ge 1 ] && [ "$DOW_ET" -le 5 ] && { [ "$HOUR_ET" -gt 18 ] || { [ "$HOUR_ET" -eq 18 ] && [ "$MIN_ET" -ge 10 ]; }; }; then
                       if [ "$OPEN_COUNT" != "0" ]; then
                         VERDICT="FAIL"
-                        REASON="Open shifts still present after 6 PM ET"
+                        REASON="Unremediated shifts created before 6 PM ET still open"
                       fi
                     else
                       REASON="Pre-6PM ET window; structural checks only"
@@ -128,7 +149,7 @@ jobs:
                   END="<!-- SCHEDULER_HISTORY_END -->"
 
                   if ! printf '%s' "$BODY" | grep -q "$START"; then
-                    HISTORY='| ET Timestamp | Fired | Open Today | Lock | Health | Verdict | Reason |\n|---|---|---:|---|---|---|---|'
+                    HISTORY='| ET Timestamp | Fired | Open <=6PM | Lock | Health | Verdict | Reason |\n|---|---|---:|---|---|---|---|'
                   else
                     HISTORY=$(printf '%s' "$BODY" | awk "/$START/{flag=1;next}/$END/{flag=0}flag")
                   fi
@@ -153,7 +174,7 @@ jobs:
                   {
                     echo "## Rolling Scheduler Verification"
                     echo
-                    echo "Single-issue weekday verification log for production scheduler health and 6 PM clock-out behavior."
+                    echo "Single-issue weekday verification log for production scheduler health and 6 PM shift remediation behavior."
                     echo
                     echo "### Trend (Pass=1, Fail=0)"
                     echo

--- a/flask_app/models/shift.py
+++ b/flask_app/models/shift.py
@@ -69,6 +69,7 @@ def enrich_with_possible_hours(employee_data, workdays):
 
 class Shift:
     db_name = "man_hours"
+    AUTO_END_TIME = "15:30:00"
 
     def __init__(self, db_data):
         self.id = db_data["id"]
@@ -549,28 +550,7 @@ class Shift:
         Returns:
             Number of shifts clocked out.
         """
-        count_query = """
-            SELECT COUNT(*) as count FROM shifts
-            WHERE updated_at IS NULL
-            AND DATE(created_at) = CURDATE();
-        """
-        count_result = connectToMySQL(cls.db_name).query_db(count_query)
-        count = count_result[0]["count"] if count_result else 0
-
-        if count > 0:
-            query = """
-                UPDATE shifts
-                SET updated_at = CASE
-                    WHEN TIME(created_at) < '15:30:00'
-                    THEN DATE_FORMAT(created_at, '%%Y-%%m-%%d 15:30:00')
-                    ELSE created_at
-                END
-                WHERE updated_at IS NULL
-                AND DATE(created_at) = CURDATE();
-            """
-            connectToMySQL(cls.db_name).query_db(query)
-
-        return count
+        return cls._close_open_shifts_where("DATE(created_at) = CURDATE()")
 
     @classmethod
     def auto_end_open_shifts_at_330pm(cls):
@@ -692,6 +672,108 @@ class Shift:
         return stale_shifts
 
     @classmethod
+    def normalized_end_time(cls, created_at):
+        """
+        Return the normalized same-day end time used by all remediation paths.
+
+        - If shift started BEFORE 3:30 PM: end at 3:30 PM same day
+        - If shift started AT or AFTER 3:30 PM: end at start time (0 duration)
+        """
+        cutoff = created_at.replace(hour=15, minute=30, second=0, microsecond=0)
+        if created_at.time() < cutoff.time():
+            return cutoff
+        return created_at
+
+    @classmethod
+    def _normalized_end_time_sql(cls, column_name="created_at"):
+        """
+        Shared SQL fragment for the normalized same-day end time rule.
+        """
+        return f"""CASE
+                WHEN TIME({column_name}) < '{cls.AUTO_END_TIME}'
+                THEN DATE_FORMAT({column_name}, '%%Y-%%m-%%d {cls.AUTO_END_TIME}')
+                ELSE {column_name}
+            END"""
+
+    @classmethod
+    def _count_rows(cls, where_clause, data=None):
+        query = f"""
+            SELECT COUNT(*) as count FROM shifts
+            WHERE {where_clause};
+        """
+        result = connectToMySQL(cls.db_name).query_db(query, data)
+        return result[0]["count"] if result else 0
+
+    @classmethod
+    def _close_open_shifts_where(cls, extra_where_clause="", data=None, limit=None):
+        """
+        Close open shifts using the shared normalized end-time rule.
+        """
+        where_parts = ["updated_at IS NULL"]
+        if extra_where_clause:
+            where_parts.append(extra_where_clause)
+        where_clause = "\n                AND ".join(where_parts)
+
+        count = cls._count_rows(where_clause, data)
+        if count == 0:
+            return 0
+
+        order_limit_sql = ""
+        if limit is not None:
+            order_limit_sql = (
+                f"\n            ORDER BY created_at ASC\n            LIMIT {int(limit)}"
+            )
+        query = f"""
+            UPDATE shifts
+            SET updated_at = {cls._normalized_end_time_sql("created_at")}
+            WHERE {where_clause}
+            {order_limit_sql};
+        """
+        connectToMySQL(cls.db_name).query_db(query, data)
+        return count if limit is None else min(count, int(limit))
+
+    @classmethod
+    def _count_multiday_shifts_where(cls):
+        return cls._count_rows(
+            "updated_at IS NOT NULL AND DATE(updated_at) != DATE(created_at)"
+        )
+
+    @classmethod
+    def _fix_multiday_shifts_where(cls):
+        count = cls._count_multiday_shifts_where()
+        if count == 0:
+            return 0
+
+        query = f"""
+            UPDATE shifts
+            SET updated_at = {cls._normalized_end_time_sql("created_at")}
+            WHERE updated_at IS NOT NULL
+            AND DATE(updated_at) != DATE(created_at);
+        """
+        connectToMySQL(cls.db_name).query_db(query)
+        return count
+
+    @classmethod
+    def run_weekday_shift_remediation(cls):
+        """
+        Close today's open shifts, sweep older missed open shifts,
+        and correct any multi-day shifts in one idempotent pass.
+
+        Returns:
+            dict: remediation counts keyed by scope
+        """
+        today_closed = cls._close_open_shifts_where("DATE(created_at) = CURDATE()")
+        older_open_closed = cls._close_open_shifts_where("DATE(created_at) < CURDATE()")
+        multiday_corrected = cls._fix_multiday_shifts_where()
+
+        return {
+            "today_closed": today_closed,
+            "older_open_closed": older_open_closed,
+            "multiday_corrected": multiday_corrected,
+            "total_affected": today_closed + older_open_closed + multiday_corrected,
+        }
+
+    @classmethod
     def fix_stale_shift(cls, shift_id):
         """
         Fix a single stale shift by setting its updated_at appropriately.
@@ -707,17 +789,8 @@ class Shift:
         Returns:
             True if successful, False otherwise
         """
-        query = """
-            UPDATE shifts
-            SET updated_at = CASE
-                WHEN TIME(created_at) < '15:30:00'
-                THEN DATE_FORMAT(created_at, '%%Y-%%m-%%d 15:30:00')
-                ELSE created_at
-            END
-            WHERE id = %(shift_id)s AND updated_at IS NULL;
-        """
-        result = connectToMySQL(cls.db_name).query_db(query, {"shift_id": shift_id})
-        return result is not False
+        count = cls._close_open_shifts_where("id = %(shift_id)s", {"shift_id": shift_id})
+        return count > 0
 
     @classmethod
     def fix_all_stale_shifts(cls, hours_threshold=12):
@@ -735,49 +808,20 @@ class Shift:
         Returns:
             Number of shifts fixed
         """
-        # Count how many shifts will be fixed BEFORE updating
-        # (ROW_COUNT() doesn't work across separate connections)
-        count_query = """
-            SELECT COUNT(*) as count FROM shifts
-            WHERE updated_at IS NULL
-            AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s;
-        """
-        count_result = connectToMySQL(cls.db_name).query_db(
-            count_query, {"hours_threshold": hours_threshold}
+        return cls._close_open_shifts_where(
+            "TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s",
+            {"hours_threshold": hours_threshold},
         )
-        count = count_result[0]["count"] if count_result else 0
-
-        if count > 0:
-            query = """
-                UPDATE shifts
-                SET updated_at = CASE
-                    WHEN TIME(created_at) < '15:30:00'
-                    THEN DATE_FORMAT(created_at, '%%Y-%%m-%%d 15:30:00')
-                    ELSE created_at
-                END
-                WHERE updated_at IS NULL
-                AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s;
-            """
-            connectToMySQL(cls.db_name).query_db(
-                query, {"hours_threshold": hours_threshold}
-            )
-
-        return count
 
     @classmethod
     def count_stale_shifts(cls, hours_threshold=12):
         """
         Count open stale shifts older than the configured threshold.
         """
-        count_query = """
-            SELECT COUNT(*) as count FROM shifts
-            WHERE updated_at IS NULL
-            AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s;
-        """
-        count_result = connectToMySQL(cls.db_name).query_db(
-            count_query, {"hours_threshold": hours_threshold}
+        return cls._count_rows(
+            "updated_at IS NULL AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s",
+            {"hours_threshold": hours_threshold},
         )
-        return count_result[0]["count"] if count_result else 0
 
     @classmethod
     def fix_stale_shifts_batch(cls, batch_size=10, hours_threshold=12):
@@ -795,27 +839,11 @@ class Shift:
         if batch_size <= 0:
             return 0
 
-        stale_count = cls.count_stale_shifts(hours_threshold=hours_threshold)
-        target_count = min(batch_size, stale_count)
-
-        if target_count > 0:
-            query = f"""
-                UPDATE shifts
-                SET updated_at = CASE
-                    WHEN TIME(created_at) < '15:30:00'
-                    THEN DATE_FORMAT(created_at, '%%Y-%%m-%%d 15:30:00')
-                    ELSE created_at
-                END
-                WHERE updated_at IS NULL
-                AND TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s
-                ORDER BY created_at ASC
-                LIMIT {int(target_count)};  -- int() cast guards copy-paste reuse
-            """
-            connectToMySQL(cls.db_name).query_db(
-                query, {"hours_threshold": hours_threshold}
-            )
-
-        return target_count
+        return cls._close_open_shifts_where(
+            "TIMESTAMPDIFF(HOUR, created_at, NOW()) >= %(hours_threshold)s",
+            {"hours_threshold": hours_threshold},
+            limit=batch_size,
+        )
 
     @classmethod
     def fix_negative_duration_shifts(cls):
@@ -859,13 +887,7 @@ class Shift:
         Count shifts where updated_at is on a different day than created_at.
         These are shifts that were clocked out days later instead of on the same day.
         """
-        query = """
-            SELECT COUNT(*) as count FROM shifts
-            WHERE updated_at IS NOT NULL
-            AND DATE(updated_at) != DATE(created_at);
-        """
-        result = connectToMySQL(cls.db_name).query_db(query)
-        return result[0]["count"] if result else 0
+        return cls._count_multiday_shifts_where()
 
     @classmethod
     def get_multiday_shifts(cls):
@@ -899,19 +921,4 @@ class Shift:
         Returns:
             Number of shifts fixed
         """
-        count = cls.count_multiday_shifts()
-
-        if count > 0:
-            query = """
-                UPDATE shifts
-                SET updated_at = CASE
-                    WHEN TIME(created_at) < '15:30:00'
-                    THEN DATE_FORMAT(created_at, '%%Y-%%m-%%d 15:30:00')
-                    ELSE created_at
-                END
-                WHERE updated_at IS NOT NULL
-                AND DATE(updated_at) != DATE(created_at);
-            """
-            connectToMySQL(cls.db_name).query_db(query)
-
-        return count
+        return cls._fix_multiday_shifts_where()

--- a/flask_app/templates/stale_shifts.html
+++ b/flask_app/templates/stale_shifts.html
@@ -163,8 +163,8 @@
 
                         <div class="info-box">
                             <i class="fas fa-info-circle me-2"></i>
-                            <strong>How this works:</strong> Stale shifts are open shifts that started more than 12 hours ago and were never clocked out.
-                            Fixing them will set their end time to <strong>3:30 PM</strong> on the day they were started.
+                            <strong>How this works:</strong> Weekday automation now sweeps open shifts at <strong>6:00 PM Eastern</strong> and normalizes them to <strong>3:30 PM</strong> on the day they were started.
+                            This page is the manual backstop for any leftovers that remain open longer than 12 hours.
                         </div>
 
                         {% if stale_shifts %}

--- a/flask_app/utils/scheduler_tasks.py
+++ b/flask_app/utils/scheduler_tasks.py
@@ -3,55 +3,58 @@ from flask_app.models.shift import Shift
 from datetime import datetime
 import logging
 
-# Set up logging for scheduler
-# StreamHandler ensures output reaches gunicorn's error log (not just root logger)
-scheduler_logger = logging.getLogger("scheduler")
-scheduler_logger.setLevel(logging.INFO)
-if not scheduler_logger.handlers:
-    scheduler_logger.addHandler(logging.StreamHandler())
+def get_scheduler_logger():
+    """
+    Route scheduler logs into Gunicorn's persisted error log when available.
+    """
+    scheduler_logger = logging.getLogger("scheduler")
+    if getattr(scheduler_logger, "_island_configured", False):
+        return scheduler_logger
+
+    gunicorn_error_logger = logging.getLogger("gunicorn.error")
+    if gunicorn_error_logger.handlers:
+        scheduler_logger.handlers = []
+        for handler in gunicorn_error_logger.handlers:
+            scheduler_logger.addHandler(handler)
+        scheduler_logger.setLevel(gunicorn_error_logger.level or logging.INFO)
+        scheduler_logger.propagate = False
+    else:
+        scheduler_logger.setLevel(logging.INFO)
+        if not scheduler_logger.handlers:
+            scheduler_logger.addHandler(logging.StreamHandler())
+
+    scheduler_logger._island_configured = True
+    return scheduler_logger
 
 
-def auto_clock_out_shifts_at_6pm_weekdays():
+scheduler_logger = get_scheduler_logger()
+
+
+def run_weekday_shift_remediation():
     """
-    Automatically close open shifts at 6:00 PM EST on weekdays.
-    End times are mapped to 3:30 PM baseline when possible.
+    Run the complete weekday shift remediation pass at 6:00 PM EST.
     """
+    logger = get_scheduler_logger()
     try:
-        scheduler_logger.info(
-            f"Starting weekday 6:00 PM auto clock-out at {datetime.now()}"
+        logger.info(
+            "SHIFT_REMEDIATION_START at=%s",
+            datetime.now().isoformat(timespec="seconds"),
         )
 
-        closed_count = Shift.auto_clock_out_open_shifts_created_today()
+        summary = Shift.run_weekday_shift_remediation()
 
-        scheduler_logger.info(
-            f"Weekday 6:00 PM auto close completed. Closed {closed_count} shifts using 3:30 PM mapping."
+        logger.info(
+            "SHIFT_REMEDIATION_COMPLETE at=%s today_closed=%s older_open_closed=%s multiday_corrected=%s total_affected=%s",
+            datetime.now().isoformat(timespec="seconds"),
+            summary["today_closed"],
+            summary["older_open_closed"],
+            summary["multiday_corrected"],
+            summary["total_affected"],
         )
-        return f"Closed {closed_count} open shifts at 6:00 PM using 3:30 PM mapping"
+        return summary
 
     except Exception as e:
-        scheduler_logger.error(f"Error in weekday 6:00 PM auto clock-out: {str(e)}")
-        return f"Error: {str(e)}"
-
-
-def auto_fix_stale_shifts():
-    """
-    Automatically fix stale shifts (open >12 hours) from previous days,
-    then correct any multi-day shifts (clocked out on a different day than started).
-    Runs at 6:30 PM EST on weekdays, 30 minutes after same-day auto clock-out.
-    """
-    try:
-        scheduler_logger.info(f"Starting stale shift cleanup at {datetime.now()}")
-
-        fixed_count = Shift.fix_all_stale_shifts(hours_threshold=12)
-        multiday_count = Shift.fix_multiday_shifts()
-
-        scheduler_logger.info(
-            f"Stale shift cleanup completed. Fixed {fixed_count} stale shifts, corrected {multiday_count} multi-day shifts."
-        )
-        return f"Fixed {fixed_count} stale shifts, corrected {multiday_count} multi-day shifts"
-
-    except Exception as e:
-        scheduler_logger.error(f"Error in stale shift cleanup: {str(e)}")
+        logger.error("SHIFT_REMEDIATION_ERROR at=%s error=%s", datetime.now(), str(e))
         return f"Error: {str(e)}"
 
 
@@ -66,17 +69,18 @@ def automated_job_sync():
     - If job exists (by IM number): Update it and make visible to production
     - If job is new: Insert it with visible_to_production=TRUE
     """
+    logger = get_scheduler_logger()
     try:
-        scheduler_logger.info(f"Starting automated Dataverse sync at {datetime.now()}")
+        logger.info(f"Starting automated Dataverse sync at {datetime.now()}")
 
         # Get approved jobs from Dataverse
         approved_jobs = Job.get_approved_jobs_from_dataverse()
-        scheduler_logger.info(
+        logger.info(
             f"Retrieved {len(approved_jobs)} approved jobs from Dataverse"
         )
 
         if not approved_jobs:
-            scheduler_logger.info("No approved jobs to process")
+            logger.info("No approved jobs to process")
             return "Sync completed. No approved jobs found in Dataverse."
 
         # OPTIMIZED: Check all IM numbers in one query instead of N queries
@@ -99,11 +103,11 @@ def automated_job_sync():
                         },
                     )
                     updated_count += 1
-                    scheduler_logger.info(
+                    logger.info(
                         f"Updated existing job IM #{job['im_number']} from Dataverse"
                     )
                 except Exception as e:
-                    scheduler_logger.error(
+                    logger.error(
                         f"Error updating job {job['im_number']}: {e}"
                     )
             else:
@@ -112,16 +116,16 @@ def automated_job_sync():
 
         # Log which new jobs are being processed
         for job in new_jobs:
-            scheduler_logger.info(f"Adding new job with IM number: {job['im_number']}")
+            logger.info(f"Adding new job with IM number: {job['im_number']}")
 
         # OPTIMIZED: Insert all new jobs in one query instead of N queries
         added_count = Job.bulk_add_records(new_jobs) if new_jobs else 0
 
-        scheduler_logger.info(
+        logger.info(
             f"Dataverse sync completed. Added: {added_count}, Updated: {updated_count}"
         )
         return f"Sync completed successfully. Added {added_count} jobs, updated {updated_count} existing jobs."
 
     except Exception as e:
-        scheduler_logger.error(f"Error in automated Dataverse sync: {str(e)}")
+        logger.error(f"Error in automated Dataverse sync: {str(e)}")
         return f"Error: {str(e)}"

--- a/server.py
+++ b/server.py
@@ -9,8 +9,8 @@ load_dotenv()  # Must be called before any flask_app imports
 
 from flask_app.utils.scheduler_tasks import (
     automated_job_sync,
-    auto_clock_out_shifts_at_6pm_weekdays,
-    auto_fix_stale_shifts,
+    get_scheduler_logger,
+    run_weekday_shift_remediation,
 )
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.schedulers.background import BackgroundScheduler
@@ -28,7 +28,7 @@ from flask_app import app
 
 # setup_webhook(sheet_id='YOUR_SHEET_ID', callback_url='YOUR_CALLBACK_URL')
 
-scheduler_logger = logging.getLogger("scheduler")
+scheduler_logger = get_scheduler_logger()
 _scheduler = None
 _scheduler_lock_file = None
 
@@ -107,20 +107,10 @@ def start_scheduler_if_enabled():
     )
 
     scheduler.add_job(
-        func=auto_clock_out_shifts_at_6pm_weekdays,
+        func=run_weekday_shift_remediation,
         trigger=CronTrigger(day_of_week="mon-fri", hour=18, minute=0, timezone=eastern),
-        id="weekday_auto_clock_out_shifts",
-        name="Weekday Auto Clock-Out Shifts at 6:00 PM",
-        replace_existing=True,
-    )
-
-    scheduler.add_job(
-        func=auto_fix_stale_shifts,
-        trigger=CronTrigger(
-            day_of_week="mon-fri", hour=18, minute=30, timezone=eastern
-        ),
-        id="auto_fix_stale_shifts",
-        name="Auto Fix Stale Shifts (>12 hrs open)",
+        id="weekday_shift_remediation",
+        name="Weekday Shift Remediation at 6:00 PM",
         replace_existing=True,
     )
 
@@ -131,7 +121,7 @@ def start_scheduler_if_enabled():
     atexit.register(_shutdown_scheduler)
 
     scheduler_logger.info(
-        "Scheduler started with daily 6AM sync, weekday 6PM auto clock-out, and 6:30PM stale shift cleanup"
+        "Scheduler started with daily 6AM sync and weekday 6PM shift remediation"
     )
     return True
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,55 @@
+"""Tests for APScheduler registration."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import server
+
+
+class FakeScheduler:
+    def __init__(self):
+        self.jobs = []
+        self.running = False
+
+    def add_job(self, **kwargs):
+        self.jobs.append(kwargs)
+
+    def start(self):
+        self.running = True
+
+    def shutdown(self, wait=False):
+        self.running = False
+
+
+def test_start_scheduler_registers_single_weekday_shift_job(monkeypatch, tmp_path):
+    fake_scheduler = FakeScheduler()
+    lock_path = tmp_path / "scheduler.lock"
+
+    monkeypatch.setattr(server, "BackgroundScheduler", lambda: fake_scheduler)
+    monkeypatch.setattr(server, "_should_start_scheduler_in_process", lambda: True)
+    monkeypatch.setattr(server.fcntl, "flock", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server.atexit, "register", lambda *args, **kwargs: None)
+    monkeypatch.setenv("SCHEDULER_LOCK_FILE", str(lock_path))
+    monkeypatch.delenv("ENABLE_SCHEDULER", raising=False)
+
+    server._scheduler = None
+    server._scheduler_lock_file = None
+
+    try:
+        assert server.start_scheduler_if_enabled() is True
+    finally:
+        server._shutdown_scheduler()
+
+    assert len(fake_scheduler.jobs) == 2
+
+    daily_sync_job = next(job for job in fake_scheduler.jobs if job["id"] == "daily_smartsheet_sync")
+    shift_job = next(job for job in fake_scheduler.jobs if job["id"] == "weekday_shift_remediation")
+
+    assert daily_sync_job["name"] == "Daily Smartsheet Job Sync"
+    assert shift_job["name"] == "Weekday Shift Remediation at 6:00 PM"
+    assert shift_job["func"] is server.run_weekday_shift_remediation
+    assert "day_of_week='mon-fri'" in str(shift_job["trigger"])
+    assert "hour='18'" in str(shift_job["trigger"])
+    assert "minute='0'" in str(shift_job["trigger"])

--- a/tests/test_shift_remediation.py
+++ b/tests/test_shift_remediation.py
@@ -1,0 +1,100 @@
+"""Tests for shared shift remediation logic."""
+
+import os
+import sys
+from datetime import datetime
+from unittest.mock import ANY, call, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from flask_app.models.shift import Shift
+from flask_app.utils import scheduler_tasks
+
+
+class TestNormalizedEndTime:
+    """Tests for the shared normalized end-time rule."""
+
+    def test_before_cutoff_maps_to_330_pm_same_day(self):
+        created_at = datetime(2026, 3, 31, 7, 3, 0)
+
+        assert Shift.normalized_end_time(created_at) == datetime(
+            2026, 3, 31, 15, 30, 0
+        )
+
+    def test_at_or_after_cutoff_maps_to_start_time(self):
+        created_at = datetime(2026, 3, 31, 15, 30, 0)
+
+        assert Shift.normalized_end_time(created_at) == created_at
+
+
+class TestWeekdayShiftRemediation:
+    """Tests for the single-pass remediation orchestration."""
+
+    def test_run_weekday_shift_remediation_returns_structured_counts(self):
+        with (
+            patch.object(
+                Shift,
+                "_close_open_shifts_where",
+                side_effect=[4, 2],
+            ) as mock_close,
+            patch.object(
+                Shift,
+                "_fix_multiday_shifts_where",
+                return_value=3,
+            ) as mock_fix_multiday,
+        ):
+            summary = Shift.run_weekday_shift_remediation()
+
+        assert summary == {
+            "today_closed": 4,
+            "older_open_closed": 2,
+            "multiday_corrected": 3,
+            "total_affected": 9,
+        }
+        mock_close.assert_has_calls(
+            [
+                call("DATE(created_at) = CURDATE()"),
+                call("DATE(created_at) < CURDATE()"),
+            ]
+        )
+        mock_fix_multiday.assert_called_once_with()
+
+    def test_run_weekday_shift_remediation_is_idempotent_when_nothing_left(self):
+        with (
+            patch.object(Shift, "_close_open_shifts_where", side_effect=[0, 0]),
+            patch.object(Shift, "_fix_multiday_shifts_where", return_value=0),
+        ):
+            summary = Shift.run_weekday_shift_remediation()
+
+        assert summary == {
+            "today_closed": 0,
+            "older_open_closed": 0,
+            "multiday_corrected": 0,
+            "total_affected": 0,
+        }
+
+    def test_scheduler_task_logs_completion_summary(self):
+        fake_summary = {
+            "today_closed": 5,
+            "older_open_closed": 1,
+            "multiday_corrected": 2,
+            "total_affected": 8,
+        }
+
+        with (
+            patch.object(Shift, "run_weekday_shift_remediation", return_value=fake_summary),
+            patch.object(scheduler_tasks, "get_scheduler_logger") as mock_get_logger,
+        ):
+            logger = mock_get_logger.return_value
+            result = scheduler_tasks.run_weekday_shift_remediation()
+
+        assert result == fake_summary
+        logger.info.assert_any_call("SHIFT_REMEDIATION_START at=%s", ANY)
+        logger.info.assert_any_call(
+            "SHIFT_REMEDIATION_COMPLETE at=%s today_closed=%s older_open_closed=%s multiday_corrected=%s total_affected=%s",
+            ANY,
+            5,
+            1,
+            2,
+            8,
+        )


### PR DESCRIPTION
## Summary
- consolidate same-day closeout, older open-shift cleanup, and multi-day correction into one 6:00 PM weekday remediation job
- route scheduler output into persisted gunicorn logging and emit a single remediation summary line for ops verification
- add tests for remediation behavior and scheduler registration, and update the rolling verification workflow to check the new log contract

## Testing
- pytest tests/test_shift_utils.py tests/test_shift_remediation.py tests/test_scheduler.py